### PR TITLE
quick-phone: use double quoted $@

### DIFF
--- a/ts-bsp/sources/meta-quickphone/recipes-quickphone/quick-phone/files/quickPhone
+++ b/ts-bsp/sources/meta-quickphone/recipes-quickphone/quick-phone/files/quickPhone
@@ -9,5 +9,5 @@ setterm -blank 0 -powersave off
 # get rid of console so it doesn't modify framebuffer
 echo 0 > /sys/class/vtconsole/vtcon1/bind
 
-cd /usr/share/quick-phone && ./quickPhone \$*
+cd /usr/share/quick-phone && ./quickPhone "$@"
 


### PR DESCRIPTION
Double-quoted $@ prevents from splitting argument with spaces.

It passes the positional arguments to the binary *as* they are given to
the wrapper script.

Note: It also fixes the spurious '\'.