### PR TITLE
alsa-state: add tailored asound.state

### DIFF
--- a/ts-bsp/sources/meta-quickphone/recipes-bsp/alsa-state/alsa-state.bbappend
+++ b/ts-bsp/sources/meta-quickphone/recipes-bsp/alsa-state/alsa-state.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend_tsimx6 := "${THISDIR}/${PN}/tsimx6:"
+
+PACKAGE_ARCH_tsimx6 = "${MACHINE_ARCH}"

--- a/ts-bsp/sources/meta-quickphone/recipes-bsp/alsa-state/alsa-state/tsimx6/asound.state
+++ b/ts-bsp/sources/meta-quickphone/recipes-bsp/alsa-state/alsa-state/tsimx6/asound.state
@@ -1,0 +1,5765 @@
+state.wm8962audio {
+	control.1 {
+		iface MIXER
+		name 'Input Mixer Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'MIXINL IN2L Volume'
+		value 5
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -1500
+			dbmax 600
+			dbvalue.0 0
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'MIXINL PGA Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin 0
+			dbmax 3000
+			dbvalue.0 0
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'MIXINL IN3L Volume'
+		value 5
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -1500
+			dbmax 600
+			dbvalue.0 0
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'MIXINR IN2R Volume'
+		value 5
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -1500
+			dbmax 600
+			dbvalue.0 0
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'MIXINR PGA Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin 0
+			dbmax 3000
+			dbvalue.0 0
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'MIXINR IN3R Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -1500
+			dbmax 600
+			dbvalue.0 600
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'Digital Capture Volume'
+		value.0 108
+		value.1 108
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 2325
+			dbvalue.0 900
+			dbvalue.1 900
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'Capture Volume'
+		value.0 40
+		value.1 40
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 63'
+			dbmin -2325
+			dbmax 2400
+			dbvalue.0 675
+			dbvalue.1 675
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'Capture Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'Capture ZC Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'Capture HPF Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'Capture HPF Mode'
+		value Hi-fi
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Hi-fi
+			item.1 Application
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'Capture HPF Cutoff'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'Capture LHPF Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'Capture LHPF Mode'
+		value LPF
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 LPF
+			item.1 HPF
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'Sidetone Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 12'
+			dbmin -3600
+			dbmax 0
+			dbvalue.0 -3600
+			dbvalue.1 -3600
+		}
+	}
+	control.18 {
+		iface MIXER
+		name 'Digital Playback Volume'
+		value.0 96
+		value.1 96
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 2325
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.19 {
+		iface MIXER
+		name 'DAC High Performance Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.20 {
+		iface MIXER
+		name 'DAC L/R Swap Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.21 {
+		iface MIXER
+		name 'ADC L/R Swap Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.22 {
+		iface MIXER
+		name 'ADC High Performance Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.23 {
+		iface MIXER
+		name 'Beep Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -9999999
+			dbmax -600
+			dbvalue.0 -9999999
+		}
+	}
+	control.24 {
+		iface MIXER
+		name 'Headphone Volume'
+		value.0 93
+		value.1 93
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 600
+			dbvalue.0 -2800
+			dbvalue.1 -2800
+		}
+	}
+	control.25 {
+		iface MIXER
+		name 'Headphone Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.26 {
+		iface MIXER
+		name 'Headphone ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.27 {
+		iface MIXER
+		name 'Headphone Aux Volume'
+		value.0 7
+		value.1 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 7'
+			dbmin -700
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.28 {
+		iface MIXER
+		name 'Headphone Mixer Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.29 {
+		iface MIXER
+		name 'HPMIXL IN4L Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -1500
+			dbmax 600
+			dbvalue.0 600
+		}
+	}
+	control.30 {
+		iface MIXER
+		name 'HPMIXL IN4R Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -1500
+			dbmax 600
+			dbvalue.0 600
+		}
+	}
+	control.31 {
+		iface MIXER
+		name 'HPMIXL MIXINL Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.32 {
+		iface MIXER
+		name 'HPMIXL MIXINR Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.33 {
+		iface MIXER
+		name 'HPMIXR IN4L Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -1500
+			dbmax 600
+			dbvalue.0 600
+		}
+	}
+	control.34 {
+		iface MIXER
+		name 'HPMIXR IN4R Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -1500
+			dbmax 600
+			dbvalue.0 600
+		}
+	}
+	control.35 {
+		iface MIXER
+		name 'HPMIXR MIXINL Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.36 {
+		iface MIXER
+		name 'HPMIXR MIXINR Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.37 {
+		iface MIXER
+		name 'Speaker Boost Volume'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin 0
+			dbmax 1200
+			dbvalue.0 450
+		}
+	}
+	control.38 {
+		iface MIXER
+		name 'EQ Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.39 {
+		iface MIXER
+		name 'EQ1 Volume'
+		value.0 12
+		value.1 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.40 {
+		iface MIXER
+		name 'EQ2 Volume'
+		value.0 12
+		value.1 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.41 {
+		iface MIXER
+		name 'EQ3 Volume'
+		value.0 12
+		value.1 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.42 {
+		iface MIXER
+		name 'EQ4 Volume'
+		value.0 12
+		value.1 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.43 {
+		iface MIXER
+		name 'EQ5 Volume'
+		value.0 12
+		value.1 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.44 {
+		iface MIXER
+		name 'EQL Coefficients'
+		value '0fca040000d81eb5f1450b7501c51c58f3730a540558168ef82907ad1103056405594000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 36
+		}
+	}
+	control.45 {
+		iface MIXER
+		name 'EQR Coefficients'
+		value '0fca040000d81eb5f1450b7501c51c58f3730a540558168ef82907ad1103056405594000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 36
+		}
+	}
+	control.46 {
+		iface MIXER
+		name '3D Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.47 {
+		iface MIXER
+		name '3D Coefficients'
+		value '0040000000000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 8
+		}
+	}
+	control.48 {
+		iface MIXER
+		name 'DF1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.49 {
+		iface MIXER
+		name 'DF1 Coefficients'
+		value '0000000000000000000000000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 14
+		}
+	}
+	control.50 {
+		iface MIXER
+		name 'DRC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.51 {
+		iface MIXER
+		name 'DRC Coefficients'
+		value '000c0925000000000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 10
+		}
+	}
+	control.52 {
+		iface MIXER
+		name 'VSS Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.53 {
+		iface MIXER
+		name 'VSS Coefficients'
+		value '008c020000350700003a4100008b7d00003a4100008cfee800780000003fb260002d18180020000000f1834000fb830000eeaec000fbac4000f17f8000f43b4000f5fb0000ea10c000fcc58000e275c00004b48000d4f9800004914000d8a48000023dc000cf7a8000dc060000f2dac000baf340000a7940001c068000fd2d00001ce840000ddc4000fc9d000009558000fe7e80000eab4000f99880000987c000fd2c400009480000035f400000870000fae4c000000b400004e18000011f4000f8b00000fbcbc00004f3800007df4000ff070000efd70000fbaf4000108a80001107c000e0080000d276000020cf400030234000fd69c0002835000006330000d9f6c000f33340000f420000040c8000fb3f8000f757c0000354000000c6c0000312c000fd8580'
+		comment {
+			access 'read write'
+			type BYTES
+			count 296
+		}
+	}
+	control.54 {
+		iface MIXER
+		name 'HPF1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.55 {
+		iface MIXER
+		name 'HPF2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.56 {
+		iface MIXER
+		name 'HPF Coefficients'
+		value '0000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 2
+		}
+	}
+	control.57 {
+		iface MIXER
+		name 'HD Bass Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.58 {
+		iface MIXER
+		name 'HD Bass Coefficients'
+		value '0002bd12007c586c00538121003f8bd80032f52d0065ac8c006be08700721483007214830043352500066a4a0043607900080000000100000059999a'
+		comment {
+			access 'read write'
+			type BYTES
+			count 60
+		}
+	}
+	control.59 {
+		iface MIXER
+		name 'ALC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.60 {
+		iface MIXER
+		name ALC1
+		value '007b'
+		comment {
+			access 'read write'
+			type BYTES
+			count 2
+		}
+	}
+	control.61 {
+		iface MIXER
+		name ALC2
+		value '0000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 2
+		}
+	}
+	control.62 {
+		iface MIXER
+		name ALC3
+		value '1c32'
+		comment {
+			access 'read write'
+			type BYTES
+			count 2
+		}
+	}
+	control.63 {
+		iface MIXER
+		name 'Noise Gate'
+		value '3200'
+		comment {
+			access 'read write'
+			type BYTES
+			count 2
+		}
+	}
+	control.64 {
+		iface MIXER
+		name 'Speaker Volume'
+		value.0 114
+		value.1 114
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 600
+			dbvalue.0 -700
+			dbvalue.1 -700
+		}
+	}
+	control.65 {
+		iface MIXER
+		name 'Speaker Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.66 {
+		iface MIXER
+		name 'Speaker ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.67 {
+		iface MIXER
+		name 'Speaker Mixer Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.68 {
+		iface MIXER
+		name 'SPKOUTL Mixer IN4L Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -1500
+			dbmax 600
+			dbvalue.0 600
+		}
+	}
+	control.69 {
+		iface MIXER
+		name 'SPKOUTL Mixer IN4R Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -1500
+			dbmax 600
+			dbvalue.0 600
+		}
+	}
+	control.70 {
+		iface MIXER
+		name 'SPKOUTL Mixer MIXINL Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.71 {
+		iface MIXER
+		name 'SPKOUTL Mixer MIXINR Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.72 {
+		iface MIXER
+		name 'SPKOUTL Mixer DACL Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 -600
+		}
+	}
+	control.73 {
+		iface MIXER
+		name 'SPKOUTL Mixer DACR Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 -600
+		}
+	}
+	control.74 {
+		iface MIXER
+		name 'SPKOUTR Mixer IN4L Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -1500
+			dbmax 600
+			dbvalue.0 600
+		}
+	}
+	control.75 {
+		iface MIXER
+		name 'SPKOUTR Mixer IN4R Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -1500
+			dbmax 600
+			dbvalue.0 600
+		}
+	}
+	control.76 {
+		iface MIXER
+		name 'SPKOUTR Mixer MIXINL Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.77 {
+		iface MIXER
+		name 'SPKOUTR Mixer MIXINR Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.78 {
+		iface MIXER
+		name 'SPKOUTR Mixer DACL Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 -600
+		}
+	}
+	control.79 {
+		iface MIXER
+		name 'SPKOUTR Mixer DACR Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 -600
+		}
+	}
+	control.80 {
+		iface MIXER
+		name 'SPKOUTR PGA'
+		value DAC
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 DAC
+			item.1 Mixer
+		}
+	}
+	control.81 {
+		iface MIXER
+		name 'SPKOUTL PGA'
+		value DAC
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 DAC
+			item.1 Mixer
+		}
+	}
+	control.82 {
+		iface MIXER
+		name 'SPKOUTR Mixer DACL Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.83 {
+		iface MIXER
+		name 'SPKOUTR Mixer DACR Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.84 {
+		iface MIXER
+		name 'SPKOUTR Mixer MIXINL Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.85 {
+		iface MIXER
+		name 'SPKOUTR Mixer MIXINR Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.86 {
+		iface MIXER
+		name 'SPKOUTR Mixer IN4L Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.87 {
+		iface MIXER
+		name 'SPKOUTR Mixer IN4R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.88 {
+		iface MIXER
+		name 'SPKOUTL Mixer DACL Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.89 {
+		iface MIXER
+		name 'SPKOUTL Mixer DACR Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.90 {
+		iface MIXER
+		name 'SPKOUTL Mixer MIXINL Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.91 {
+		iface MIXER
+		name 'SPKOUTL Mixer MIXINR Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.92 {
+		iface MIXER
+		name 'SPKOUTL Mixer IN4L Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.93 {
+		iface MIXER
+		name 'SPKOUTL Mixer IN4R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.94 {
+		iface MIXER
+		name 'HPOUTR PGA'
+		value DAC
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 DAC
+			item.1 Mixer
+		}
+	}
+	control.95 {
+		iface MIXER
+		name 'HPOUTL PGA'
+		value DAC
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 DAC
+			item.1 Mixer
+		}
+	}
+	control.96 {
+		iface MIXER
+		name 'HPMIXR DACL Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.97 {
+		iface MIXER
+		name 'HPMIXR DACR Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.98 {
+		iface MIXER
+		name 'HPMIXR MIXINL Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.99 {
+		iface MIXER
+		name 'HPMIXR MIXINR Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.100 {
+		iface MIXER
+		name 'HPMIXR IN4L Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.101 {
+		iface MIXER
+		name 'HPMIXR IN4R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.102 {
+		iface MIXER
+		name 'HPMIXL DACL Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.103 {
+		iface MIXER
+		name 'HPMIXL DACR Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.104 {
+		iface MIXER
+		name 'HPMIXL MIXINL Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.105 {
+		iface MIXER
+		name 'HPMIXL MIXINR Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.106 {
+		iface MIXER
+		name 'HPMIXL IN4L Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.107 {
+		iface MIXER
+		name 'HPMIXL IN4R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.108 {
+		iface MIXER
+		name STR
+		value None
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 None
+			item.1 Left
+			item.2 Right
+		}
+	}
+	control.109 {
+		iface MIXER
+		name STL
+		value None
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 None
+			item.1 Left
+			item.2 Right
+		}
+	}
+	control.110 {
+		iface MIXER
+		name 'MIXINR IN2R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.111 {
+		iface MIXER
+		name 'MIXINR IN3R Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.112 {
+		iface MIXER
+		name 'MIXINR PGA Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.113 {
+		iface MIXER
+		name 'MIXINL IN2L Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.114 {
+		iface MIXER
+		name 'MIXINL IN3L Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.115 {
+		iface MIXER
+		name 'MIXINL PGA Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.116 {
+		iface MIXER
+		name 'INPGAR IN1R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.117 {
+		iface MIXER
+		name 'INPGAR IN2R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.118 {
+		iface MIXER
+		name 'INPGAR IN3R Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.119 {
+		iface MIXER
+		name 'INPGAR IN4R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.120 {
+		iface MIXER
+		name 'INPGAL IN1L Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.121 {
+		iface MIXER
+		name 'INPGAL IN2L Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.122 {
+		iface MIXER
+		name 'INPGAL IN3L Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.123 {
+		iface MIXER
+		name 'INPGAL IN4L Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.124 {
+		iface CARD
+		name 'Headphone Jack'
+		value true
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+}
+state.wm8960audio {
+	control.1 {
+		iface MIXER
+		name 'Capture Volume'
+		value.0 35
+		value.1 35
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 63'
+			dbmin -1725
+			dbmax 3000
+			dbvalue.0 900
+			dbvalue.1 900
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'Capture Volume ZC Switch'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 1'
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'Capture Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'Right Input Boost Mixer RINPUT3 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 600
+			dbvalue.0 -9999999
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'Right Input Boost Mixer RINPUT2 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 600
+			dbvalue.0 -9999999
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'Left Input Boost Mixer LINPUT3 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 600
+			dbvalue.0 -9999999
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'Left Input Boost Mixer LINPUT2 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 600
+			dbvalue.0 -9999999
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'Right Input Boost Mixer RINPUT1 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 3'
+			dbmin 0
+			dbmax 2900
+			dbvalue.0 0
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'Left Input Boost Mixer LINPUT1 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 3'
+			dbmin 0
+			dbmax 2900
+			dbvalue.0 0
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'Playback Volume'
+		value.0 235
+		value.1 235
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 -1000
+			dbvalue.1 -1000
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'Headphone Playback Volume'
+		value.0 101
+		value.1 101
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 600
+			dbvalue.0 -2000
+			dbvalue.1 -2000
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'Headphone Playback ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'Speaker Playback Volume'
+		value.0 110
+		value.1 110
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 600
+			dbvalue.0 -1100
+			dbvalue.1 -1100
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'Speaker Playback ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'Speaker DC Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 5'
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'Speaker AC Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 5'
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'PCM Playback -6dB Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.18 {
+		iface MIXER
+		name 'ADC Polarity'
+		value 'No Inversion'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'No Inversion'
+			item.1 'Left Inverted'
+			item.2 'Right Inverted'
+			item.3 'Stereo Inversion'
+		}
+	}
+	control.19 {
+		iface MIXER
+		name 'ADC High Pass Filter Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.20 {
+		iface MIXER
+		name 'DAC Polarity'
+		value 'No Inversion'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'No Inversion'
+			item.1 'Left Inverted'
+			item.2 'Right Inverted'
+			item.3 'Stereo Inversion'
+		}
+	}
+	control.21 {
+		iface MIXER
+		name 'DAC Deemphasis Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.22 {
+		iface MIXER
+		name '3D Filter Upper Cut-Off'
+		value High
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 High
+			item.1 Low
+		}
+	}
+	control.23 {
+		iface MIXER
+		name '3D Filter Lower Cut-Off'
+		value Low
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Low
+			item.1 High
+		}
+	}
+	control.24 {
+		iface MIXER
+		name '3D Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+		}
+	}
+	control.25 {
+		iface MIXER
+		name '3D Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.26 {
+		iface MIXER
+		name 'ALC Function'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 Right
+			item.2 Left
+			item.3 Stereo
+		}
+	}
+	control.27 {
+		iface MIXER
+		name 'ALC Max Gain'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.28 {
+		iface MIXER
+		name 'ALC Target'
+		value 4
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+		}
+	}
+	control.29 {
+		iface MIXER
+		name 'ALC Min Gain'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.30 {
+		iface MIXER
+		name 'ALC Hold Time'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+		}
+	}
+	control.31 {
+		iface MIXER
+		name 'ALC Mode'
+		value ALC
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 ALC
+			item.1 Limiter
+		}
+	}
+	control.32 {
+		iface MIXER
+		name 'ALC Decay'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+		}
+	}
+	control.33 {
+		iface MIXER
+		name 'ALC Attack'
+		value 2
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+		}
+	}
+	control.34 {
+		iface MIXER
+		name 'Noise Gate Threshold'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+		}
+	}
+	control.35 {
+		iface MIXER
+		name 'Noise Gate Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.36 {
+		iface MIXER
+		name 'ADC PCM Capture Volume'
+		value.0 195
+		value.1 195
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 3000
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.37 {
+		iface MIXER
+		name 'Left Output Mixer Boost Bypass Volume'
+		value 2
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 -1500
+		}
+	}
+	control.38 {
+		iface MIXER
+		name 'Left Output Mixer LINPUT3 Volume'
+		value 2
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 -1500
+		}
+	}
+	control.39 {
+		iface MIXER
+		name 'Right Output Mixer Boost Bypass Volume'
+		value 2
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 -1500
+		}
+	}
+	control.40 {
+		iface MIXER
+		name 'Right Output Mixer RINPUT3 Volume'
+		value 2
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 -1500
+		}
+	}
+	control.41 {
+		iface MIXER
+		name 'ADC Data Output Select'
+		value 'Left Data = Left ADC;  Right Data = Left ADC'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'Left Data = Left ADC;  Right Data = Right ADC'
+			item.1 'Left Data = Left ADC;  Right Data = Left ADC'
+			item.2 'Left Data = Right ADC; Right Data = Right ADC'
+			item.3 'Left Data = Right ADC; Right Data = Left ADC'
+		}
+	}
+	control.42 {
+		iface MIXER
+		name 'Mono Output Mixer Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.43 {
+		iface MIXER
+		name 'Mono Output Mixer Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.44 {
+		iface MIXER
+		name 'Right Output Mixer PCM Playback Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.45 {
+		iface MIXER
+		name 'Right Output Mixer RINPUT3 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.46 {
+		iface MIXER
+		name 'Right Output Mixer Boost Bypass Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.47 {
+		iface MIXER
+		name 'Left Output Mixer PCM Playback Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.48 {
+		iface MIXER
+		name 'Left Output Mixer LINPUT3 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.49 {
+		iface MIXER
+		name 'Left Output Mixer Boost Bypass Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.50 {
+		iface MIXER
+		name 'Right Input Mixer Boost Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.51 {
+		iface MIXER
+		name 'Left Input Mixer Boost Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.52 {
+		iface MIXER
+		name 'Right Boost Mixer RINPUT2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.53 {
+		iface MIXER
+		name 'Right Boost Mixer RINPUT3 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.54 {
+		iface MIXER
+		name 'Right Boost Mixer RINPUT1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.55 {
+		iface MIXER
+		name 'Left Boost Mixer LINPUT2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.56 {
+		iface MIXER
+		name 'Left Boost Mixer LINPUT3 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.57 {
+		iface MIXER
+		name 'Left Boost Mixer LINPUT1 Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.58 {
+		iface CARD
+		name 'Headphone Jack'
+		value true
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+}
+state.wm8958audio {
+	control.1 {
+		iface MIXER
+		name 'AIF1.1 DRC'
+		value '00980845000000000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 10
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'AIF1.2 DRC'
+		value '00980845000000000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 10
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'AIF2 DRC'
+		value '00980845000000000000'
+		comment {
+			access 'read write'
+			type BYTES
+			count 10
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'AIF1DAC1 EQ1 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'AIF1DAC1 EQ2 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'AIF1DAC1 EQ3 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'AIF1DAC1 EQ4 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'AIF1DAC1 EQ5 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'AIF1DAC2 EQ1 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'AIF1DAC2 EQ2 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'AIF1DAC2 EQ3 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'AIF1DAC2 EQ4 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'AIF1DAC2 EQ5 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'AIF2 EQ1 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'AIF2 EQ2 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'AIF2 EQ3 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'AIF2 EQ4 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.18 {
+		iface MIXER
+		name 'AIF2 EQ5 Volume'
+		value 12
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1200
+			dbmax 1900
+			dbvalue.0 0
+		}
+	}
+	control.19 {
+		iface MIXER
+		name 'IN1L Volume'
+		value 11
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1650
+			dbmax 3000
+			dbvalue.0 0
+		}
+	}
+	control.20 {
+		iface MIXER
+		name 'IN1L Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.21 {
+		iface MIXER
+		name 'IN1L ZC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.22 {
+		iface MIXER
+		name 'IN1R Volume'
+		value 11
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1650
+			dbmax 3000
+			dbvalue.0 0
+		}
+	}
+	control.23 {
+		iface MIXER
+		name 'IN1R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.24 {
+		iface MIXER
+		name 'IN1R ZC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.25 {
+		iface MIXER
+		name 'IN2L Volume'
+		value 11
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1650
+			dbmax 3000
+			dbvalue.0 0
+		}
+	}
+	control.26 {
+		iface MIXER
+		name 'IN2L Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.27 {
+		iface MIXER
+		name 'IN2L ZC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.28 {
+		iface MIXER
+		name 'IN2R Volume'
+		value 11
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -1650
+			dbmax 3000
+			dbvalue.0 0
+		}
+	}
+	control.29 {
+		iface MIXER
+		name 'IN2R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.30 {
+		iface MIXER
+		name 'IN2R ZC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.31 {
+		iface MIXER
+		name 'MIXINL IN2L Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin 0
+			dbmax 3000
+			dbvalue.0 0
+		}
+	}
+	control.32 {
+		iface MIXER
+		name 'MIXINL IN1L Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin 0
+			dbmax 3000
+			dbvalue.0 0
+		}
+	}
+	control.33 {
+		iface MIXER
+		name 'MIXINL Output Record Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 600
+			dbvalue.0 -9999999
+		}
+	}
+	control.34 {
+		iface MIXER
+		name 'MIXINL IN1LP Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 600
+			dbvalue.0 -9999999
+		}
+	}
+	control.35 {
+		iface MIXER
+		name 'MIXINL Direct Voice Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 6'
+			dbmin -9999999
+			dbmax 300
+			dbvalue.0 -9999999
+		}
+	}
+	control.36 {
+		iface MIXER
+		name 'MIXINR IN2R Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin 0
+			dbmax 3000
+			dbvalue.0 0
+		}
+	}
+	control.37 {
+		iface MIXER
+		name 'MIXINR IN1R Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin 0
+			dbmax 3000
+			dbvalue.0 0
+		}
+	}
+	control.38 {
+		iface MIXER
+		name 'MIXINR Output Record Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 600
+			dbvalue.0 -9999999
+		}
+	}
+	control.39 {
+		iface MIXER
+		name 'MIXINR IN1RP Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 600
+			dbvalue.0 -9999999
+		}
+	}
+	control.40 {
+		iface MIXER
+		name 'MIXINR Direct Voice Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 6'
+			dbmin -9999999
+			dbmax 300
+			dbvalue.0 -9999999
+		}
+	}
+	control.41 {
+		iface MIXER
+		name 'Left Output Mixer IN2RN Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.42 {
+		iface MIXER
+		name 'Left Output Mixer IN2LN Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.43 {
+		iface MIXER
+		name 'Left Output Mixer IN2LP Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.44 {
+		iface MIXER
+		name 'Left Output Mixer IN1L Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.45 {
+		iface MIXER
+		name 'Left Output Mixer IN1R Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.46 {
+		iface MIXER
+		name 'Left Output Mixer Right Input Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.47 {
+		iface MIXER
+		name 'Left Output Mixer Left Input Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.48 {
+		iface MIXER
+		name 'Left Output Mixer DAC Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.49 {
+		iface MIXER
+		name 'Right Output Mixer IN2LN Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.50 {
+		iface MIXER
+		name 'Right Output Mixer IN2RN Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.51 {
+		iface MIXER
+		name 'Right Output Mixer IN1L Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.52 {
+		iface MIXER
+		name 'Right Output Mixer IN1R Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.53 {
+		iface MIXER
+		name 'Right Output Mixer IN2RP Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.54 {
+		iface MIXER
+		name 'Right Output Mixer Left Input Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.55 {
+		iface MIXER
+		name 'Right Output Mixer Right Input Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.56 {
+		iface MIXER
+		name 'Right Output Mixer DAC Volume'
+		value 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -2100
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.57 {
+		iface MIXER
+		name 'Output Volume'
+		value.0 57
+		value.1 57
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 63'
+			dbmin -5700
+			dbmax 600
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.58 {
+		iface MIXER
+		name 'Output Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.59 {
+		iface MIXER
+		name 'Output ZC Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.60 {
+		iface MIXER
+		name 'Earpiece Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.61 {
+		iface MIXER
+		name 'Earpiece Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.62 {
+		iface MIXER
+		name 'SPKL Input Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -300
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.63 {
+		iface MIXER
+		name 'SPKL IN1LP Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -300
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.64 {
+		iface MIXER
+		name 'SPKL Output Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -300
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.65 {
+		iface MIXER
+		name 'SPKR Input Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -300
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.66 {
+		iface MIXER
+		name 'SPKR IN1RP Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -300
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.67 {
+		iface MIXER
+		name 'SPKR Output Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -300
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.68 {
+		iface MIXER
+		name 'Speaker Mixer Volume'
+		value.0 3
+		value.1 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 3'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.69 {
+		iface MIXER
+		name 'Speaker Volume'
+		value.0 60
+		value.1 60
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 63'
+			dbmin -5700
+			dbmax 600
+			dbvalue.0 300
+			dbvalue.1 300
+		}
+	}
+	control.70 {
+		iface MIXER
+		name 'Speaker Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.71 {
+		iface MIXER
+		name 'Speaker ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.72 {
+		iface MIXER
+		name 'Speaker Boost Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 7'
+			dbmin 0
+			dbmax 1200
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.73 {
+		iface MIXER
+		name 'Speaker Reference'
+		value SPKVDD/2
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 SPKVDD/2
+			item.1 VMID
+		}
+	}
+	control.74 {
+		iface MIXER
+		name 'Speaker Mode'
+		value 'Class D'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'Class D'
+			item.1 'Class AB'
+		}
+	}
+	control.75 {
+		iface MIXER
+		name 'Headphone Volume'
+		value.0 25
+		value.1 25
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 63'
+			dbmin -5700
+			dbmax 600
+			dbvalue.0 -3200
+			dbvalue.1 -3200
+		}
+	}
+	control.76 {
+		iface MIXER
+		name 'Headphone Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.77 {
+		iface MIXER
+		name 'Headphone ZC Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.78 {
+		iface MIXER
+		name 'LINEOUT1N Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.79 {
+		iface MIXER
+		name 'LINEOUT1P Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.80 {
+		iface MIXER
+		name 'LINEOUT1 Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.81 {
+		iface MIXER
+		name 'LINEOUT2N Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.82 {
+		iface MIXER
+		name 'LINEOUT2P Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.83 {
+		iface MIXER
+		name 'LINEOUT2 Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -600
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.84 {
+		iface MIXER
+		name 'AIF1ADC1 Volume'
+		value.0 96
+		value.1 96
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 119'
+			dbmin -9999999
+			dbmax 1725
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.85 {
+		iface MIXER
+		name 'AIF1ADC2 Volume'
+		value.0 96
+		value.1 96
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 119'
+			dbmin -9999999
+			dbmax 1725
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.86 {
+		iface MIXER
+		name 'AIF2ADC Volume'
+		value.0 96
+		value.1 96
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 119'
+			dbmin -9999999
+			dbmax 1725
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.87 {
+		iface MIXER
+		name 'AIF1ADCL Source'
+		value Left
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Left
+			item.1 Right
+		}
+	}
+	control.88 {
+		iface MIXER
+		name 'AIF1ADCR Source'
+		value Left
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Left
+			item.1 Right
+		}
+	}
+	control.89 {
+		iface MIXER
+		name 'AIF2ADCL Source'
+		value Left
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Left
+			item.1 Right
+		}
+	}
+	control.90 {
+		iface MIXER
+		name 'AIF2ADCR Source'
+		value Right
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Left
+			item.1 Right
+		}
+	}
+	control.91 {
+		iface MIXER
+		name 'AIF1DACL Source'
+		value Left
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Left
+			item.1 Right
+		}
+	}
+	control.92 {
+		iface MIXER
+		name 'AIF1DACR Source'
+		value Right
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Left
+			item.1 Right
+		}
+	}
+	control.93 {
+		iface MIXER
+		name 'AIF2DACL Source'
+		value Left
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Left
+			item.1 Right
+		}
+	}
+	control.94 {
+		iface MIXER
+		name 'AIF2DACR Source'
+		value Right
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Left
+			item.1 Right
+		}
+	}
+	control.95 {
+		iface MIXER
+		name 'AIF1DAC1 Volume'
+		value.0 96
+		value.1 96
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 96'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.96 {
+		iface MIXER
+		name 'AIF1DAC2 Volume'
+		value.0 96
+		value.1 96
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 96'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.97 {
+		iface MIXER
+		name 'AIF2DAC Volume'
+		value.0 96
+		value.1 96
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 96'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.98 {
+		iface MIXER
+		name 'AIF1 Boost Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 3'
+			dbmin 0
+			dbmax 1800
+			dbvalue.0 0
+		}
+	}
+	control.99 {
+		iface MIXER
+		name 'AIF2 Boost Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 3'
+			dbmin 0
+			dbmax 1800
+			dbvalue.0 0
+		}
+	}
+	control.100 {
+		iface MIXER
+		name 'AIF1DAC1 EQ Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.101 {
+		iface MIXER
+		name 'AIF1DAC2 EQ Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.102 {
+		iface MIXER
+		name 'AIF2 EQ Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.103 {
+		iface MIXER
+		name 'AIF1DAC1 DRC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.104 {
+		iface MIXER
+		name 'AIF1ADC1L DRC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.105 {
+		iface MIXER
+		name 'AIF1ADC1R DRC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.106 {
+		iface MIXER
+		name 'AIF1DAC2 DRC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.107 {
+		iface MIXER
+		name 'AIF1ADC2L DRC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.108 {
+		iface MIXER
+		name 'AIF1ADC2R DRC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.109 {
+		iface MIXER
+		name 'AIF2DAC DRC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.110 {
+		iface MIXER
+		name 'AIF2ADCL DRC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.111 {
+		iface MIXER
+		name 'AIF2ADCR DRC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.112 {
+		iface MIXER
+		name 'DAC1 Right Sidetone Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 12'
+			dbmin -3600
+			dbmax 0
+			dbvalue.0 -3600
+		}
+	}
+	control.113 {
+		iface MIXER
+		name 'DAC1 Left Sidetone Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 12'
+			dbmin -3600
+			dbmax 0
+			dbvalue.0 -3600
+		}
+	}
+	control.114 {
+		iface MIXER
+		name 'DAC2 Right Sidetone Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 12'
+			dbmin -3600
+			dbmax 0
+			dbvalue.0 -3600
+		}
+	}
+	control.115 {
+		iface MIXER
+		name 'DAC2 Left Sidetone Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 12'
+			dbmin -3600
+			dbmax 0
+			dbvalue.0 -3600
+		}
+	}
+	control.116 {
+		iface MIXER
+		name 'Sidetone HPF Mux'
+		value '2.7kHz'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '2.7kHz'
+			item.1 '1.35kHz'
+			item.2 '675Hz'
+			item.3 '370Hz'
+			item.4 '180Hz'
+			item.5 '90Hz'
+			item.6 '45Hz'
+		}
+	}
+	control.117 {
+		iface MIXER
+		name 'Sidetone HPF Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.118 {
+		iface MIXER
+		name 'AIF1ADC1 HPF Mode'
+		value HiFi
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 HiFi
+			item.1 'Voice 1'
+			item.2 'Voice 2'
+			item.3 'Voice 3'
+		}
+	}
+	control.119 {
+		iface MIXER
+		name 'AIF1ADC1 HPF Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.120 {
+		iface MIXER
+		name 'AIF1ADC2 HPF Mode'
+		value HiFi
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 HiFi
+			item.1 'Voice 1'
+			item.2 'Voice 2'
+			item.3 'Voice 3'
+		}
+	}
+	control.121 {
+		iface MIXER
+		name 'AIF1ADC2 HPF Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.122 {
+		iface MIXER
+		name 'AIF2ADC HPF Mode'
+		value HiFi
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 HiFi
+			item.1 'Voice 1'
+			item.2 'Voice 2'
+			item.3 'Voice 3'
+		}
+	}
+	control.123 {
+		iface MIXER
+		name 'AIF2ADC HPF Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.124 {
+		iface MIXER
+		name 'ADC OSR'
+		value 'High Performance'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'Low Power'
+			item.1 'High Performance'
+		}
+	}
+	control.125 {
+		iface MIXER
+		name 'DAC OSR'
+		value 'Low Power'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'Low Power'
+			item.1 'High Performance'
+		}
+	}
+	control.126 {
+		iface MIXER
+		name 'DAC1 Volume'
+		value.0 96
+		value.1 96
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 96'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.127 {
+		iface MIXER
+		name 'DAC1 Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.128 {
+		iface MIXER
+		name 'DAC2 Volume'
+		value.0 96
+		value.1 96
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 96'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.129 {
+		iface MIXER
+		name 'DAC2 Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.130 {
+		iface MIXER
+		name 'SPKL DAC2 Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -300
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.131 {
+		iface MIXER
+		name 'SPKL DAC1 Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -300
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.132 {
+		iface MIXER
+		name 'SPKR DAC2 Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -300
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.133 {
+		iface MIXER
+		name 'SPKR DAC1 Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+			dbmin -300
+			dbmax 0
+			dbvalue.0 0
+		}
+	}
+	control.134 {
+		iface MIXER
+		name 'AIF1DAC1 3D Stereo Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1600
+			dbmax 1145
+			dbvalue.0 -1600
+		}
+	}
+	control.135 {
+		iface MIXER
+		name 'AIF1DAC1 3D Stereo Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.136 {
+		iface MIXER
+		name 'AIF1DAC2 3D Stereo Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1600
+			dbmax 1145
+			dbvalue.0 -1600
+		}
+	}
+	control.137 {
+		iface MIXER
+		name 'AIF1DAC2 3D Stereo Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.138 {
+		iface MIXER
+		name 'AIF2DAC 3D Stereo Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1600
+			dbmax 1145
+			dbvalue.0 -1600
+		}
+	}
+	control.139 {
+		iface MIXER
+		name 'AIF2DAC 3D Stereo Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.140 {
+		iface MIXER
+		name 'AIF3 Boost Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 3'
+			dbmin 0
+			dbmax 1800
+			dbvalue.0 0
+		}
+	}
+	control.141 {
+		iface MIXER
+		name 'AIF1DAC1 Noise Gate Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.142 {
+		iface MIXER
+		name 'AIF1DAC1 Noise Gate Hold Time'
+		value '30ms'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '30ms'
+			item.1 '125ms'
+			item.2 '250ms'
+			item.3 '500ms'
+		}
+	}
+	control.143 {
+		iface MIXER
+		name 'AIF1DAC1 Noise Gate Threshold Volume'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -10200
+			dbmax -6000
+			dbvalue.0 -8400
+		}
+	}
+	control.144 {
+		iface MIXER
+		name 'AIF1DAC2 Noise Gate Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.145 {
+		iface MIXER
+		name 'AIF1DAC2 Noise Gate Hold Time'
+		value '30ms'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '30ms'
+			item.1 '125ms'
+			item.2 '250ms'
+			item.3 '500ms'
+		}
+	}
+	control.146 {
+		iface MIXER
+		name 'AIF1DAC2 Noise Gate Threshold Volume'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -10200
+			dbmax -6000
+			dbvalue.0 -8400
+		}
+	}
+	control.147 {
+		iface MIXER
+		name 'AIF2DAC Noise Gate Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.148 {
+		iface MIXER
+		name 'AIF2DAC Noise Gate Hold Time'
+		value '30ms'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '30ms'
+			item.1 '125ms'
+			item.2 '250ms'
+			item.3 '500ms'
+		}
+	}
+	control.149 {
+		iface MIXER
+		name 'AIF2DAC Noise Gate Threshold Volume'
+		value 3
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -10200
+			dbmax -6000
+			dbvalue.0 -8400
+		}
+	}
+	control.150 {
+		iface MIXER
+		name 'AIF1DAC1 MBC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.151 {
+		iface MIXER
+		name 'AIF1DAC2 MBC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.152 {
+		iface MIXER
+		name 'AIF2DAC MBC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.153 {
+		iface MIXER
+		name 'AIF1DAC1 VSS Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.154 {
+		iface MIXER
+		name 'AIF1DAC2 VSS Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.155 {
+		iface MIXER
+		name 'AIF2DAC VSS Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.156 {
+		iface MIXER
+		name 'AIF1DAC1 HPF1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.157 {
+		iface MIXER
+		name 'AIF1DAC2 HPF1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.158 {
+		iface MIXER
+		name 'AIF2DAC HPF1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.159 {
+		iface MIXER
+		name 'AIF1DAC1 HPF2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.160 {
+		iface MIXER
+		name 'AIF1DAC2 HPF2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.161 {
+		iface MIXER
+		name 'AIF2DAC HPF2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.162 {
+		iface MIXER
+		name 'AIF1DAC1 Enhanced EQ Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.163 {
+		iface MIXER
+		name 'AIF1DAC2 Enhanced EQ Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.164 {
+		iface MIXER
+		name 'AIF2DAC Enhanced EQ Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.165 {
+		iface MIXER
+		name 'ADCR Mux'
+		value ADC
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 ADC
+			item.1 DMIC
+		}
+	}
+	control.166 {
+		iface MIXER
+		name 'ADCL Mux'
+		value ADC
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 ADC
+			item.1 DMIC
+		}
+	}
+	control.167 {
+		iface MIXER
+		name 'Right Headphone Mux'
+		value DAC
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Mixer
+			item.1 DAC
+		}
+	}
+	control.168 {
+		iface MIXER
+		name 'Left Headphone Mux'
+		value DAC
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Mixer
+			item.1 DAC
+		}
+	}
+	control.169 {
+		iface MIXER
+		name 'SPKR DAC2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.170 {
+		iface MIXER
+		name 'SPKR Input Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.171 {
+		iface MIXER
+		name 'SPKR IN1RP Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.172 {
+		iface MIXER
+		name 'SPKR Output Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.173 {
+		iface MIXER
+		name 'SPKR DAC1 Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.174 {
+		iface MIXER
+		name 'SPKL DAC2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.175 {
+		iface MIXER
+		name 'SPKL Input Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.176 {
+		iface MIXER
+		name 'SPKL IN1LP Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.177 {
+		iface MIXER
+		name 'SPKL Output Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.178 {
+		iface MIXER
+		name 'SPKL DAC1 Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.179 {
+		iface MIXER
+		name 'AIF3ADC Mux'
+		value AIF1ADCDAT
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 AIF1ADCDAT
+			item.1 AIF2ADCDAT
+			item.2 AIF2DACDAT
+			item.3 'Mono PCM'
+		}
+	}
+	control.180 {
+		iface MIXER
+		name 'AIF2DACR Mux'
+		value AIF2
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 AIF2
+			item.1 AIF3
+		}
+	}
+	control.181 {
+		iface MIXER
+		name 'AIF2DACL Mux'
+		value AIF2
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 AIF2
+			item.1 AIF3
+		}
+	}
+	control.182 {
+		iface MIXER
+		name 'Mono PCM Out Mux'
+		value None
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 None
+			item.1 AIF2ADCL
+			item.2 AIF2ADCR
+		}
+	}
+	control.183 {
+		iface MIXER
+		name 'AIF2 Loopback'
+		value None
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 None
+			item.1 ADCDAT
+		}
+	}
+	control.184 {
+		iface MIXER
+		name 'AIF1 Loopback'
+		value None
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 None
+			item.1 ADCDAT
+		}
+	}
+	control.185 {
+		iface MIXER
+		name 'AIF2ADC Mux'
+		value AIF2ADCDAT
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 AIF2ADCDAT
+			item.1 AIF3DACDAT
+		}
+	}
+	control.186 {
+		iface MIXER
+		name 'AIF2DAC Mux'
+		value AIF2DACDAT
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 AIF2DACDAT
+			item.1 AIF3DACDAT
+		}
+	}
+	control.187 {
+		iface MIXER
+		name 'AIF1DAC Mux'
+		value AIF1DACDAT
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 AIF1DACDAT
+			item.1 AIF3DACDAT
+		}
+	}
+	control.188 {
+		iface MIXER
+		name 'DAC1R Mixer Right Sidetone Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.189 {
+		iface MIXER
+		name 'DAC1R Mixer Left Sidetone Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.190 {
+		iface MIXER
+		name 'DAC1R Mixer AIF2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.191 {
+		iface MIXER
+		name 'DAC1R Mixer AIF1.2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.192 {
+		iface MIXER
+		name 'DAC1R Mixer AIF1.1 Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.193 {
+		iface MIXER
+		name 'DAC1L Mixer Right Sidetone Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.194 {
+		iface MIXER
+		name 'DAC1L Mixer Left Sidetone Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.195 {
+		iface MIXER
+		name 'DAC1L Mixer AIF2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.196 {
+		iface MIXER
+		name 'DAC1L Mixer AIF1.2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.197 {
+		iface MIXER
+		name 'DAC1L Mixer AIF1.1 Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.198 {
+		iface MIXER
+		name 'Right Sidetone'
+		value ADC/DMIC1
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 ADC/DMIC1
+			item.1 DMIC2
+		}
+	}
+	control.199 {
+		iface MIXER
+		name 'Left Sidetone'
+		value ADC/DMIC1
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 ADC/DMIC1
+			item.1 DMIC2
+		}
+	}
+	control.200 {
+		iface MIXER
+		name 'AIF2DAC2R Mixer Right Sidetone Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.201 {
+		iface MIXER
+		name 'AIF2DAC2R Mixer Left Sidetone Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.202 {
+		iface MIXER
+		name 'AIF2DAC2R Mixer AIF2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.203 {
+		iface MIXER
+		name 'AIF2DAC2R Mixer AIF1.2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.204 {
+		iface MIXER
+		name 'AIF2DAC2R Mixer AIF1.1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.205 {
+		iface MIXER
+		name 'AIF2DAC2L Mixer Right Sidetone Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.206 {
+		iface MIXER
+		name 'AIF2DAC2L Mixer Left Sidetone Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.207 {
+		iface MIXER
+		name 'AIF2DAC2L Mixer AIF2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.208 {
+		iface MIXER
+		name 'AIF2DAC2L Mixer AIF1.2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.209 {
+		iface MIXER
+		name 'AIF2DAC2L Mixer AIF1.1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.210 {
+		iface MIXER
+		name 'AIF1ADC2R Mixer DMIC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.211 {
+		iface MIXER
+		name 'AIF1ADC2R Mixer AIF2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.212 {
+		iface MIXER
+		name 'AIF1ADC2L Mixer DMIC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.213 {
+		iface MIXER
+		name 'AIF1ADC2L Mixer AIF2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.214 {
+		iface MIXER
+		name 'AIF1ADC1R Mixer ADC/DMIC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.215 {
+		iface MIXER
+		name 'AIF1ADC1R Mixer AIF2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.216 {
+		iface MIXER
+		name 'AIF1ADC1L Mixer ADC/DMIC Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.217 {
+		iface MIXER
+		name 'AIF1ADC1L Mixer AIF2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.218 {
+		iface MIXER
+		name 'LINEOUT2P Mixer Right Output Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.219 {
+		iface MIXER
+		name 'LINEOUT2N Mixer Left Output Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.220 {
+		iface MIXER
+		name 'LINEOUT2N Mixer Right Output Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.221 {
+		iface MIXER
+		name 'LINEOUT1P Mixer Left Output Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.222 {
+		iface MIXER
+		name 'LINEOUT1N Mixer Left Output Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.223 {
+		iface MIXER
+		name 'LINEOUT1N Mixer Right Output Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.224 {
+		iface MIXER
+		name 'SPKR Boost Direct Voice Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.225 {
+		iface MIXER
+		name 'SPKR Boost SPKL Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.226 {
+		iface MIXER
+		name 'SPKR Boost SPKR Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.227 {
+		iface MIXER
+		name 'SPKL Boost Direct Voice Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.228 {
+		iface MIXER
+		name 'SPKL Boost SPKL Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.229 {
+		iface MIXER
+		name 'SPKL Boost SPKR Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.230 {
+		iface MIXER
+		name 'Earpiece Mixer Direct Voice Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.231 {
+		iface MIXER
+		name 'Earpiece Mixer Left Output Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.232 {
+		iface MIXER
+		name 'Earpiece Mixer Right Output Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.233 {
+		iface MIXER
+		name 'Right Output Mixer Left Input Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.234 {
+		iface MIXER
+		name 'Right Output Mixer Right Input Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.235 {
+		iface MIXER
+		name 'Right Output Mixer IN2LN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.236 {
+		iface MIXER
+		name 'Right Output Mixer IN2RN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.237 {
+		iface MIXER
+		name 'Right Output Mixer IN1L Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.238 {
+		iface MIXER
+		name 'Right Output Mixer IN1R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.239 {
+		iface MIXER
+		name 'Right Output Mixer IN2RP Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.240 {
+		iface MIXER
+		name 'Right Output Mixer DAC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.241 {
+		iface MIXER
+		name 'Left Output Mixer Right Input Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.242 {
+		iface MIXER
+		name 'Left Output Mixer Left Input Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.243 {
+		iface MIXER
+		name 'Left Output Mixer IN2RN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.244 {
+		iface MIXER
+		name 'Left Output Mixer IN2LN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.245 {
+		iface MIXER
+		name 'Left Output Mixer IN2LP Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.246 {
+		iface MIXER
+		name 'Left Output Mixer IN1R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.247 {
+		iface MIXER
+		name 'Left Output Mixer IN1L Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.248 {
+		iface MIXER
+		name 'Left Output Mixer DAC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.249 {
+		iface MIXER
+		name 'MIXINR IN2R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.250 {
+		iface MIXER
+		name 'MIXINR IN1R Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.251 {
+		iface MIXER
+		name 'MIXINL IN2L Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.252 {
+		iface MIXER
+		name 'MIXINL IN1L Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.253 {
+		iface MIXER
+		name 'IN2R PGA IN2RP Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.254 {
+		iface MIXER
+		name 'IN2R PGA IN2RN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.255 {
+		iface MIXER
+		name 'IN2L PGA IN2LP Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.256 {
+		iface MIXER
+		name 'IN2L PGA IN2LN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.257 {
+		iface MIXER
+		name 'IN1R PGA IN1RP Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.258 {
+		iface MIXER
+		name 'IN1R PGA IN1RN Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.259 {
+		iface MIXER
+		name 'IN1L PGA IN1LP Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.260 {
+		iface MIXER
+		name 'IN1L PGA IN1LN Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.261 {
+		iface CARD
+		name 'Headphone Jack'
+		value true
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+}
+state.cs42888audio {
+	control.1 {
+		iface MIXER
+		name 'DAC1 Playback Volume'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'DAC2 Playback Volume'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'DAC3 Playback Volume'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'DAC4 Playback Volume'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'ADC1 Capture Volume'
+		value.0 128
+		value.1 128
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 176'
+			dbmin -6400
+			dbmax 2400
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'ADC2 Capture Volume'
+		value.0 128
+		value.1 128
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 176'
+			dbmin -6400
+			dbmax 2400
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'DAC1 Invert Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'DAC2 Invert Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'DAC3 Invert Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'DAC4 Invert Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'ADC1 Invert Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'ADC2 Invert Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'ADC High-Pass Filter Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'DAC De-emphasis Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'ADC1 Single Ended Mode Switch'
+		value Differential
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Differential
+			item.1 Single-Ended
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'ADC2 Single Ended Mode Switch'
+		value Differential
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Differential
+			item.1 Single-Ended
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'DAC Single Volume Control Switch'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+		}
+	}
+	control.18 {
+		iface MIXER
+		name 'DAC Soft Ramp & Zero Cross Control Switch'
+		value 'Immediate Change'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'Immediate Change'
+			item.1 'Zero Cross'
+			item.2 'Soft Ramp'
+			item.3 'Soft Ramp on Zero Cross'
+		}
+	}
+	control.19 {
+		iface MIXER
+		name 'DAC Auto Mute Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.20 {
+		iface MIXER
+		name 'Mute ADC Serial Port Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.21 {
+		iface MIXER
+		name 'ADC Single Volume Control Switch'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 1'
+		}
+	}
+	control.22 {
+		iface MIXER
+		name 'ADC Soft Ramp & Zero Cross Control Switch'
+		value 'Immediate Change'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'Immediate Change'
+			item.1 'Zero Cross'
+			item.2 'Soft Ramp'
+			item.3 'Soft Ramp on Zero Cross'
+		}
+	}
+}
+state.imxhdmisoc {
+	control.1 {
+		iface MIXER
+		name 'IEC958 Playback Default'
+		value '0400020200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read write volatile'
+			type IEC958
+			count 1
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'HDMI Support Channels'
+		value 2
+		comment {
+			access 'read volatile'
+			type INTEGER
+			count 1
+			range '0 - 0'
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'HDMI Support Rates'
+		value.0 32000
+		value.1 44100
+		value.2 48000
+		comment {
+			access 'read volatile'
+			type INTEGER
+			count 3
+			range '0 - 0'
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'HDMI Support Formats'
+		value 16
+		comment {
+			access 'read volatile'
+			type INTEGER
+			count 1
+			range '0 - 0'
+		}
+	}
+}
+state.sii902xaudio {
+	control {
+	}
+}
+state.Codec {
+	control.1 {
+		iface MIXER
+		name 'PCM Playback Volume'
+		value.0 172
+		value.1 172
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 192'
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'Capture Volume'
+		value.0 10
+		value.1 10
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 15'
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'Capture Attenuate Switch (-6dB)'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'Capture ZC Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'Headphone Playback Volume'
+		value.0 127
+		value.1 127
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -5150
+			dbmax 1200
+			dbvalue.0 1200
+			dbvalue.1 1200
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'Headphone Playback ZC Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'Mic Volume'
+		value 2
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 3'
+			dbmin 0
+			dbmax 4000
+			dbvalue.0 3000
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'Headphone Mux'
+		value DAC
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 DAC
+			item.1 LINE_IN
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'Capture Mux'
+		value MIC_IN
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 MIC_IN
+			item.1 LINE_IN
+		}
+	}
+}
+state.Device {
+	control.1 {
+		iface PCM
+		name 'Playback Channel Map'
+		value.0 0
+		value.1 0
+		comment {
+			access read
+			type INTEGER
+			count 2
+			range '0 - 36'
+		}
+	}
+	control.2 {
+		iface PCM
+		name 'Capture Channel Map'
+		value 0
+		comment {
+			access read
+			type INTEGER
+			count 1
+			range '0 - 36'
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'Mic Playback Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'Mic Playback Volume'
+		value 31
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 31'
+			dbmin -2300
+			dbmax 800
+			dbvalue.0 800
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'Speaker Playback Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'Speaker Playback Volume'
+		value.0 17
+		value.1 17
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 37'
+			dbmin -3700
+			dbmax 0
+			dbvalue.0 -2000
+			dbvalue.1 -2000
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'Mic Capture Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'Mic Capture Volume'
+		value 32
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 35'
+			dbmin -1200
+			dbmax 2300
+			dbvalue.0 2000
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'Auto Gain Control'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+}


### PR DESCRIPTION
This commit adds the ALSA configuration required to configure the audio
properly on the interphone.